### PR TITLE
feat(itemLogs): Delay log requests for 30s

### DIFF
--- a/icpc-frontned/src/app/components/logging/HeartbeatComponent.tsx
+++ b/icpc-frontned/src/app/components/logging/HeartbeatComponent.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { useEffect } from 'react'
+import useAuthStore from '@/store/useStore'
+import useExcerciseStore from '@/store/useExcerciseStore'
+import useNoteStore from '@/store/useNoteStore'
+
+interface HeartbeatComponentProps {
+  itemId: string
+  itemType: 'exercise' | 'note'
+}
+
+export default function HeartbeatComponent({ itemId, itemType }: Readonly<HeartbeatComponentProps>) {
+  const isLoggedIn = useAuthStore(state => state.isLogged)
+  const logExercise = useExcerciseStore(state => state.log)
+  const logNote = useNoteStore(state => state.log)
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout
+    const sendHeartbeat = () => {
+      if (!isLoggedIn) {
+        if (itemType === 'exercise') {
+          logExercise(itemId)
+        }
+        else if (itemType === 'note') {
+            logNote(itemId)
+        }
+      }
+    }
+    // Start after 30 seconds
+    const timeoutId = setTimeout(() => {
+      sendHeartbeat() // Optionally send once at 30s
+      intervalId = setInterval(sendHeartbeat, 300000) // 5 min
+    }, 30000)
+    return () => {
+      clearTimeout(timeoutId)
+      if (intervalId) clearInterval(intervalId)
+    }
+  }, [])
+  return null
+}

--- a/icpc-frontned/src/app/exercises/[exercise]/page.tsx
+++ b/icpc-frontned/src/app/exercises/[exercise]/page.tsx
@@ -4,7 +4,7 @@ import useExcerciseStore from '@/store/useExcerciseStore'
 import { serialize } from 'next-mdx-remote/serialize'
 import rehypeKatex from 'rehype-katex'
 import remarkMath from 'remark-math'
-import useAuthStore from '@/store/useStore'
+import HeartbeatComponent from '@/app/components/logging/HeartbeatComponent'
 
 async function getMarkdown(body: string) {
   return await serialize(body, {
@@ -18,14 +18,11 @@ async function getMarkdown(body: string) {
 async function ExercisePage({ params }: Readonly<{ params: { exercise: string } }>) {
   const exerciseBody = await useExcerciseStore.getState().getExercise(params.exercise)
   const description = await getMarkdown(exerciseBody.description)
-  const isLoggedIn = useAuthStore.getState().isLogged
   const solution = await getMarkdown(exerciseBody.solution)
-  if (!isLoggedIn) {
-    useExcerciseStore.getState().log(params.exercise)
-  }
 
   return (
     <main className='grid min-h-screen grid-cols-1 place-items-center justify-between w-full py-24'>
+      <HeartbeatComponent itemId={params.exercise} itemType='exercise' />
       <div className='flex justify-end w-full'>
         <ExerciseCardComponent
           exercise={exerciseBody}

--- a/icpc-frontned/src/app/note/[id]/page.tsx
+++ b/icpc-frontned/src/app/note/[id]/page.tsx
@@ -6,10 +6,9 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import useNoteStore from '@/store/useNoteStore'
 import { Note } from '@/constants/types'
-import useAuthStore from '@/store/useStore'
+import HeartbeatComponent from '@/app/components/logging/HeartbeatComponent'
 
 export default async function Page({ params }: Readonly<{ params: { id: string } }>) {
-  const isLoggedIn = useAuthStore.getState().isLogged
   const getNote = useNoteStore.getState().getNote
   if (params.id) {
     const note: Note = await getNote(params.id)
@@ -19,11 +18,9 @@ export default async function Page({ params }: Readonly<{ params: { id: string }
         rehypePlugins: [rehypeKatex as any]
       }
     })
-    if (!isLoggedIn) {
-      useNoteStore.getState().log(params.id)
-    }
     return (
       <main className='grid min-h-screen grid-cols-1 place-items-center justify-between py-24'>
+        <HeartbeatComponent itemId={note.id} itemType='note' />
         <NoteCardComponent
           title={note.title}
           description={note.commentId.body}


### PR DESCRIPTION
Created a new HeartbeatComponent that sends a log request after 30 seconds of loading the page and every 5 minutes after that in order to log the exercises and notes read during the most time