### PR TITLE
fix(cloudStorage): Fix ENOENT error when uploading image

### DIFF
--- a/icpc-backend/src/image/image.service.ts
+++ b/icpc-backend/src/image/image.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { UpdateImageDto } from './dto/update-image.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Image } from './entities/image.entity';
@@ -69,8 +68,8 @@ export class ImageService {
     });
     if (!imageInDb) {
       // If the image does not exist, save the file and store metadata in the database
-      /*fs.writeFile(
-        process.cwd() + process.env.ASSETS_PATH + '/' + image.assetName,
+      fs.writeFile(
+        process.cwd() + '/publicAssets/' + image.assetName,
         file.buffer,
         err => {
           if (err) {
@@ -78,7 +77,7 @@ export class ImageService {
             throw err;
           }
         }
-      );*/
+      );
       const bucket = await this.getBucket();
       const res = await bucket.upload(
         `${process.cwd()}/publicAssets/${image.assetName}`,


### PR DESCRIPTION
Part of the commented code was important to upload images to the Cloud Storage bucket. The commented code created a local copy of the image for upload, which is a necessary step for the flow of data during the creation of a news article. The commented code also had an incorrect call of an env variable, attempting to use the name of the bucket as part of the path of the local copy of the image to upload, this has been fixed.

MAKE SURE TO HAVE A "publicAssets" FOLDER