### PR TITLE
fix(mailRoleCheck): Check the role when creating an item

### DIFF
--- a/icpc-backend/src/excercises/excercises.service.ts
+++ b/icpc-backend/src/excercises/excercises.service.ts
@@ -151,13 +151,15 @@ export class ExcercisesService {
       commentId: commentId
     });
     const savedTicket = await this.ticketRepository.save(ticket);
-    this.mailerService.sendMail(
-      true,
-      'create',
-      savedExcercise.title,
-      'ejercicio'
-    );
     if (savedExcercise && savedTicket) {
+      if (createExcerciseDto.role !== 'admin') {
+        this.mailerService.sendMail(
+          true,
+          'create',
+          savedExcercise.title,
+          'ejercicio'
+        );
+      }
       // If both the exercise and ticket are saved, return the exercise
       return savedExcercise;
     } else {

--- a/icpc-backend/src/news/news.service.ts
+++ b/icpc-backend/src/news/news.service.ts
@@ -93,7 +93,14 @@ export class NewsService {
       });
       const savedTicket = await this.ticketRepository.save(ticket);
       if (savedNews && savedTicket) {
-        this.mailerService.sendMail(true, 'create', savedNews.title, 'noticia');
+        if (createNewsDto.role !== 'admin') {
+          this.mailerService.sendMail(
+            true,
+            'create',
+            savedNews.title,
+            'noticia'
+          );
+        }
         return savedNews;
       } else {
         throw new BadRequestException('Error al crear la noticia');


### PR DESCRIPTION
Perform a check of the account's role when creating an item. If the role is admin, the email notification is not sent. This is done in order to reduce the amount of notifications sent during the database population stage