### PR TITLE
refactor: centralize image URL rendering

### DIFF
--- a/icpc-frontned/src/app/components/cards/NewsCardComponent.tsx
+++ b/icpc-frontned/src/app/components/cards/NewsCardComponent.tsx
@@ -8,6 +8,7 @@ import { serialize } from 'next-mdx-remote/serialize'
 import rehypeKatex from 'rehype-katex'
 import remarkMath from 'remark-math'
 import ReportButtonComponent from '../buttons/ReportButtonComponent'
+import { resolveMarkdownImages } from '@/utils/markdown'
 
 interface NewsCardComponentProps {
   id: string
@@ -31,7 +32,8 @@ async function getNewsArticle(id: string): Promise<News> {
 
 async function NewsCardComponent({ isTicketPage = false, ...props  }: Readonly<NewsCardComponentProps>) {
   const news = await getNewsArticle(props.id)
-  const body = await serialize(news.body, {
+  const normalizedBody = resolveMarkdownImages(news.body)
+  const body = await serialize(normalizedBody, {
     mdxOptions: {
       remarkPlugins: [remarkMath],
       rehypePlugins: [rehypeKatex as any]

--- a/icpc-frontned/src/app/exercises/[exercise]/page.tsx
+++ b/icpc-frontned/src/app/exercises/[exercise]/page.tsx
@@ -5,6 +5,7 @@ import { serialize } from 'next-mdx-remote/serialize'
 import rehypeKatex from 'rehype-katex'
 import remarkMath from 'remark-math'
 import HeartbeatComponent from '@/app/components/logging/HeartbeatComponent'
+import { resolveMarkdownImages } from '@/utils/markdown'
 
 /*
 Input: params (object with exercise id from the route)
@@ -17,7 +18,8 @@ Author: Alan Julian Itzamna Mier Cupul
 */
 
 async function getMarkdown(body: string) {
-  return await serialize(body, {
+  const normalizedBody = resolveMarkdownImages(body)
+  return await serialize(normalizedBody, {
     mdxOptions: {
       remarkPlugins: [remarkMath],
       rehypePlugins: [rehypeKatex as any]

--- a/icpc-frontned/src/app/note/[id]/page.tsx
+++ b/icpc-frontned/src/app/note/[id]/page.tsx
@@ -7,6 +7,7 @@ import rehypeKatex from 'rehype-katex'
 import useNoteStore from '@/store/useNoteStore'
 import { Note } from '@/constants/types'
 import HeartbeatComponent from '@/app/components/logging/HeartbeatComponent'
+import { resolveMarkdownImages } from '@/utils/markdown'
 
 /*
 Input: params (object with id from the route)
@@ -23,7 +24,8 @@ export default async function Page({ params }: Readonly<{ params: { id: string }
   const getNote = useNoteStore.getState().getNote
   if (params.id) {
     const note: Note = await getNote(params.id)
-    const mdx = await serialize(note.body, {
+    const normalizedBody = resolveMarkdownImages(note.body)
+    const mdx = await serialize(normalizedBody, {
       mdxOptions: {
         remarkPlugins: [remarkMath],
         rehypePlugins: [rehypeKatex as any]

--- a/icpc-frontned/src/app/ticket/[id]/page.tsx
+++ b/icpc-frontned/src/app/ticket/[id]/page.tsx
@@ -9,6 +9,7 @@ import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
 import { TextComponent } from '@/app/components/text/TextComponent'
 import { TicketActions } from '@/app/ticket/TicketActions'
+import { resolveMarkdownImages } from '@/utils/markdown'
 
 /*
 Input: params (object with id from the route)
@@ -25,7 +26,8 @@ const TicketPage = async ({ params }: Readonly<{ params: { id: string } }>) => {
   const ticket: Ticket = await useUtilsStore.getState().getTicket(params.id)
 
   async function serializeNote(mdx: string) {
-    return await serialize(mdx, {
+    const normalizedBody = resolveMarkdownImages(mdx)
+    return await serialize(normalizedBody, {
       mdxOptions: {
         remarkPlugins: [remarkMath],
         rehypePlugins: [rehypeKatex as any]

--- a/icpc-frontned/src/utils/markdown.ts
+++ b/icpc-frontned/src/utils/markdown.ts
@@ -1,0 +1,15 @@
+/**
+ * Replace custom @img/ image references in Markdown with a fully qualified URL.
+ * Leaves the content untouched when the base URL is not available.
+ */
+export function resolveMarkdownImages(markdown: string): string {
+  const baseUrl = process.env.NEXT_PUBLIC_OMM_IMAGES_BASE_URL
+  if (!baseUrl) return markdown
+
+  const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
+
+  return markdown.replace(/@img\/[^\s)]+/g, match => {
+    const imagePath = match.replace(/^@img\//, '')
+    return `${normalizedBaseUrl}/${imagePath}`
+  })
+}


### PR DESCRIPTION
### Frontend only

The application supports a custom image syntax in Markdown using `@img/` paths.
Before rendering the content, these paths are dynamically resolved into full image URLs using a centralized base URL defined in the `NEXT_PUBLIC_OMM_IMAGES_BASE_URL` environment variable.
